### PR TITLE
Bug fix (short values for R-R data from sensor)

### DIFF
--- a/app/src/main/java/eu/fistar/sdcs/pa/da/zephyrbh/ZephyrBHConnectedListener.java
+++ b/app/src/main/java/eu/fistar/sdcs/pa/da/zephyrbh/ZephyrBHConnectedListener.java
@@ -372,7 +372,7 @@ public class ZephyrBHConnectedListener extends ConnectListenerImpl {
 
         // Convert short values to String
         for (int i = 0; i < samples.length; i++) {
-            strSamples[i] = Integer.toString(samples[i]);
+            strSamples[i] = Short.toString((short) samples[i]);
         }
 
         // Create the Observation object


### PR DESCRIPTION
R to R measurements were reported falsely. Based on the documentation for R to R: Alternating ± sign at new detection. If Integer is used then the negative value (when R to R is changed) becomes a large positive value (instead of negative), because the native format is Short.
